### PR TITLE
Correct code with phpstan till level 8

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,7 +7,7 @@ parameters:
         - src/
 
     # Level 9 is the highest level
-    level: 6
+    level: 8
 
 #    ignoreErrors:
 #        - '#PHPDoc tag @var#'

--- a/src/Translatable/Locales.php
+++ b/src/Translatable/Locales.php
@@ -75,6 +75,11 @@ class Locales implements Arrayable, ArrayAccess
         return explode($this->getLocaleSeparator(), $locale)[0];
     }
 
+    /**
+     * Retrieves the locale separator string from the configuration.
+     *
+     * @return non-empty-string The locale separator string obtained from the configuration, or '-' if not configured.
+     */
     public function getLocaleSeparator(): string
     {
         return $this->config->get('translatable.locale_separator') ?: '-';

--- a/src/Translatable/TranslatableServiceProvider.php
+++ b/src/Translatable/TranslatableServiceProvider.php
@@ -29,9 +29,11 @@ class TranslatableServiceProvider extends ServiceProvider
         );
 
         Rule::macro('translatableUnique', function (string $model, string $field): TranslatableUnique {
+            /** @var class-string<\Illuminate\Database\Eloquent\Model> $model */
             return new TranslatableUnique($model, $field);
         });
         Rule::macro('translatableExists', function (string $model, string $field): TranslatableExists {
+            /** @var class-string<\Illuminate\Database\Eloquent\Model> $model */
             return new TranslatableExists($model, $field);
         });
 

--- a/src/Translatable/Validation/RuleFactory.php
+++ b/src/Translatable/Validation/RuleFactory.php
@@ -105,8 +105,10 @@ class RuleFactory
                 continue;
             }
 
-            foreach ($this->locales as $locale) {
-                $rules[$this->formatKey($locale, $key)] = $this->formatRule($locale, $value);
+            if (! is_null($this->locales)) {
+                foreach ($this->locales as $locale) {
+                    $rules[$this->formatKey($locale, $key)] = $this->formatRule($locale, $value);
+                }
             }
         }
 
@@ -143,7 +145,7 @@ class RuleFactory
 
     protected function replacePlaceholder(string $locale, string $value): string
     {
-        return preg_replace($this->getPattern(), $this->getReplacement($locale), $value);
+        return preg_replace($this->getPattern(), $this->getReplacement($locale), $value) ?? $value;
     }
 
     protected function getReplacement(string $locale): string


### PR DESCRIPTION
Upgrade phpstan tell level 8.

Rule Levels
5. checking types of arguments passed to methods and functions
6. report missing typehints
7. report partially wrong union types - if you call a method that only exists on some types in a union type, level 7 starts to report that; other possibly incorrect situations
8. report calling methods and accessing properties on nullable types